### PR TITLE
Add an uninstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ effort required on your part.
   * [Install the plugin](#install-the-plugin)
   * [Configure the plugin](#configure-the-plugin)
 * [Usage](#usage)
+* [Uninstallation](#uninstallation)
 * [Troubleshooting](#troubleshooting)
 * [Known Issues](#known-issues)
 * [Development](#development)
@@ -84,6 +85,16 @@ your DNS cluster. You can change this information on this screen later.
 
 After installation the plugin automatically sends DNS change to StackPath's DNS 
 backend with no interaction required by the user.
+
+<a name="uninstallation"></a>
+## Uninstallation
+
+1. Copy this project to a temporary directory on your cPanel server.
+2. Execute the `uninstall.sh` script as root. This removes all files and 
+directories installed by the `install.sh` script. 
+
+After the plugin is uninstalled then cPanel will no longer synchronize DNS zone 
+changes with StackPath.
 
 <a name="troubleshooting"></a>
 ## Troubleshooting

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# StackPath dnsadmin uninstaller
+#
+# Remove the plugin's Perl modules from a cPanel installation.
+
+CPANEL_ROOT="/usr/local/cpanel"
+REMOTE_MODULE="Cpanel/NameServer/Remote/StackPath.pm"
+SETUP_MODULE="Cpanel/NameServer/Setup/Remote/StackPath.pm"
+PROJECT_URL="https://github.com/stackpath/cpanel-dnsadmin-plugin"
+
+# Remove a directory with pretty output
+remove_directory() {
+    echo -n "${1}... "
+    if [[ ! -d ${1} ]]; then
+        echo "SKIPPED: not present"
+    elif RESULT=$(rm -rf ${1} 2>&1); then
+        echo "OK"
+    else
+        echo "FAILED"
+        echo ${RESULT}
+        echo
+        echo "Unable to remove ${1}."
+        echo "Please contact your systems administrator and try again."
+        echo
+
+        exit 1
+    fi
+}
+
+# Remove a file with pretty output
+remove_file() {
+    echo -n "${1}... "
+    if [[ ! -f ${1} ]]; then
+        echo "SKIPPED: not present"
+    elif RESULT=$(rm ${1} 2>&1); then
+        echo "OK"
+    else
+        echo "FAILED"
+        echo ${RESULT}
+        echo
+        echo "Unable to remove ${1}."
+        echo "Please contact your systems administrator and try again."
+        echo
+
+        exit 1
+    fi
+}
+
+echo "Welcome to the StackPath dnsadmin plugin uninstaller"
+echo "----------"
+echo
+echo "Removing directories"
+remove_directory "${CPANEL_ROOT}/Cpanel/NameServer/Remote/StackPath"
+
+echo
+echo "Removing files"
+remove_file "${CPANEL_ROOT}/${REMOTE_MODULE}"
+remove_file "${CPANEL_ROOT}/${SETUP_MODULE}"
+
+# All done!
+echo
+echo "----------"
+echo "The StackPath dnsadmin plugin has been uninstalled."
+echo "Please download the plugin and run install.sh to reinstall it."
+echo
+echo ${PROJECT_URL}
+echo "https://stackpath.com/"
+echo


### PR DESCRIPTION
Changes proposed in this pull request:
* Add an uninstaller that removed all files created by `install.sh`.
* Update the README to show how to uninstall the plugin.
